### PR TITLE
Added export to namespaces

### DIFF
--- a/src/printer.ts
+++ b/src/printer.ts
@@ -41,7 +41,7 @@ export function print(interfaceNodes, inputKind: ts.SyntaxKind, options: JsonTsO
         });
         const ns = ts.createModuleDeclaration(
             undefined,
-            [ts.createToken(ts.SyntaxKind.DeclareKeyword)],
+            [ts.createToken(ts.SyntaxKind.ExportKeyword), ts.createToken(ts.SyntaxKind.DeclareKeyword)],
             ts.createIdentifier(options.namespace),
             ts.createModuleBlock(interfaceNodes),
             ts.NodeFlags.Namespace


### PR DESCRIPTION
It's not possible to import interfaces unless their namespace is exported as well